### PR TITLE
Drop manuGMG SOCKS5 source (404 Not Found)

### DIFF
--- a/ProxyScrape.sh
+++ b/ProxyScrape.sh
@@ -38,7 +38,6 @@ SOCKS5_PROXY_SOURCE=(
     "https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks5.txt"
     "https://raw.githubusercontent.com/hookzof/socks5_list/master/proxy.txt"
     "https://raw.githubusercontent.com/jetkai/proxy-list/main/online-proxies/txt/proxies.txt"
-    "https://raw.githubusercontent.com/manuGMG/proxy-365/main/SOCKS5.txt"
     "https://raw.githubusercontent.com/monosans/proxy-list/main/proxies/socks5.txt"
     "https://raw.githubusercontent.com/roosterkid/openproxylist/main/SOCKS5_RAW.txt"
     "https://raw.githubusercontent.com/prxchk/proxy-list/main/socks5.txt"


### PR DESCRIPTION
### **User description**
Endpoint now returns 404 Not Found.

Keeping it only wastes retries and slows the scraper.


___

### **PR Type**
Other


___

### **Description**
- Remove non-functional manuGMG SOCKS5 proxy source

- Clean up dead endpoint returning 404 errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SOCKS5 Proxy Sources"] -- "remove" --> B["Dead manuGMG endpoint"]
  A --> C["Active proxy sources remain"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProxyScrape.sh</strong><dd><code>Remove dead proxy source endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ProxyScrape.sh

<ul><li>Remove manuGMG SOCKS5 proxy source URL from array<br> <li> Clean up dead endpoint that returns 404 errors</ul>


</details>


  </td>
  <td><a href="https://github.com/PeterDaveHello/ProxyScrape.sh/pull/3/files#diff-94721b75a771cd1f4d98bf88030418ccd8d2a2f3e778caca66a3d7f07b3866ef">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the SOCKS5 proxy source list by removing one source URL.
  * No changes to proxy fetching, deduplication, or output behavior; results should appear as before.
  * No configuration or usage changes required.
  * Existing scripts and integrations continue to work without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->